### PR TITLE
Add CLAUDE.md, rules, and skills scaffolding from agentic principles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md
+
+This file is a **routing directory** — not a context dump. Read only what applies to your current task.
+
+---
+
+## After Every Compaction
+
+1. Re-read your current task plan.
+2. Re-read the files relevant to that task.
+3. Do NOT assume context you haven't explicitly read.
+
+---
+
+## Routing
+
+| Situation | Read |
+|---|---|
+| Before writing any code | `rules/coding-rules.md` |
+| Before writing or running tests | `rules/testing-rules.md` |
+| Tests are failing | `rules/debugging-rules.md` |
+| Starting a new task | `rules/task-contracts.md` |
+| Unsure how to approach a problem | `skills/` — find the matching skill file |
+
+---
+
+## Core Principles (always active)
+
+- **Precision over research**: If given a specific implementation, implement it. Do not research alternatives unless explicitly asked.
+- **Context discipline**: Only load context directly relevant to the task. Ignore everything else.
+- **Neutral analysis**: Do not bias findings. Report what you observe; do not engineer results to satisfy a prompt.
+- **Task completion**: A task is NOT done when code is written. It is done when the task contract is fulfilled (see `rules/task-contracts.md`).
+- **No assumptions**: If you don't know something, ask. Do not fill gaps with guesses.
+- **Less is more**: Do not add features, refactors, helpers, or abstractions beyond what is asked.

--- a/rules/coding-rules.md
+++ b/rules/coding-rules.md
@@ -1,0 +1,23 @@
+# Coding Rules
+
+## Precision
+- Implement exactly what is specified. Do not research or evaluate alternatives unless the task explicitly says to.
+- If implementation details are missing, STOP and ask before proceeding.
+- Separate research sessions from implementation sessions. Never mix the two in the same context.
+
+## Scope
+- Do not add features, error handling, helpers, or abstractions beyond what was asked.
+- Do not add comments, docstrings, or type annotations to code you did not change.
+- Do not refactor surrounding code when fixing a bug.
+
+## Context
+- Only read files directly relevant to the current task.
+- Do not read files "just in case" — only read what you need.
+
+## Prompting yourself
+- Do not bias your own analysis. If reviewing code, report findings neutrally. Do not engineer bugs or successes.
+- If asked to "find bugs", instead: "search through the code, follow the logic, and report all findings."
+
+## Quality gates
+- Do not mark a task complete until the task contract is fulfilled (see `rules/task-contracts.md`).
+- Do not stub implementations. Incomplete = not done.

--- a/rules/debugging-rules.md
+++ b/rules/debugging-rules.md
@@ -1,0 +1,20 @@
+# Debugging Rules (Tests Failing)
+
+## Before doing anything
+1. Re-read the task contract (`rules/task-contracts.md`).
+2. Re-read the failing test(s) carefully.
+3. Re-read the implementation files relevant to the failure.
+
+## Diagnosis
+- Follow the logic explicitly. Do not assume. Trace the actual execution path.
+- Report findings neutrally — do not engineer a diagnosis to match expectations.
+- Identify the root cause before touching any code.
+
+## Fixing
+- Fix the root cause, not the symptom.
+- Do not edit tests. Do not add workarounds or guards that mask the real issue.
+- Do not change unrelated code while fixing the bug.
+
+## After fixing
+- Re-run all tests (not just the failing one) before marking done.
+- Confirm the fix does not break the task contract.

--- a/rules/task-contracts.md
+++ b/rules/task-contracts.md
@@ -1,0 +1,36 @@
+# Task Contracts
+
+## What is a task contract?
+A task contract defines what "done" means for a specific task. A task is NOT complete until every item in its contract is fulfilled.
+
+## Contract format
+For each task, create a file: `contracts/{TASK_NAME}_contract.md`
+
+Template:
+```
+# {TASK_NAME} Contract
+
+## Objective
+[One sentence describing the goal]
+
+## Implementation checklist
+- [ ] ...
+
+## Tests that must pass
+- [ ] `test_name_here`
+- [ ] ...
+
+## Verification
+- [ ] Manual check / screenshot / output confirms expected behavior
+
+## Done when
+All boxes above are checked.
+```
+
+## Rules
+- You are NOT allowed to terminate a task session until all contract items are checked.
+- You are NOT allowed to mark a test as passing without actually running it.
+- If a contract item is ambiguous, STOP and ask for clarification before proceeding.
+
+## One contract per session
+Each working session should target one contract. Do not mix contracts in the same session — it causes context bloat and drift.

--- a/rules/testing-rules.md
+++ b/rules/testing-rules.md
@@ -1,0 +1,15 @@
+# Testing Rules
+
+## Tests as task endpoints
+- Tests are the primary completion signal for a task. Unless specified otherwise, a task is NOT done until all relevant tests pass.
+- Do NOT edit tests to make them pass. Fix the implementation instead.
+- Tests must be deterministic. Do not write tests that rely on timing, random state, or external network unless explicitly required.
+
+## Writing tests
+- Test the behavior described in the task, not the implementation details.
+- One clear assertion per test case where possible.
+- Name tests so the failure message is self-explanatory.
+
+## Verification
+- After tests pass, confirm the behavior matches the task contract before declaring done.
+- If screenshot/visual verification is part of the contract, do not skip it.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,30 @@
+# Skills
+
+Skills encode **how** to do something — specific recipes for recurring tasks.
+
+Add a skill when:
+- You have a specific, repeatable approach to a problem
+- You want to make agent behavior deterministic for a scenario
+- You've seen an agent solve something well and want to lock in that approach
+
+## Naming
+`skills/{scenario-name}.md`
+
+## Referenced from
+`CLAUDE.md` routing table — add a row when you add a skill.
+
+## Format
+```
+# Skill: {name}
+
+## When to use this
+[Trigger condition]
+
+## Steps
+1. ...
+2. ...
+3. ...
+
+## Constraints
+- ...
+```


### PR DESCRIPTION
Encodes the principles from @systematicls: CLAUDE.md as a lean routing
directory (not a context dump), conditional rules for coding/testing/debugging,
task contracts as completion gates, and a skills scaffold for repeatable recipes.

https://claude.ai/code/session_01MiCcLh9zEiHk9G2tFqPDpU